### PR TITLE
refactor: map models as dataclasses

### DIFF
--- a/src/models/game_map.py
+++ b/src/models/game_map.py
@@ -101,7 +101,7 @@ class GameMap:
 
     def to_json(self, path: str) -> None:
         with open(path, "w") as file:
-            json.dump(self.to_dict(), file, indent=4)
+            json.dump(self.to_dict(), file, indent=2)
 
 
 class MapUUIDs(Enum):

--- a/src/models/map.py
+++ b/src/models/map.py
@@ -1,53 +1,118 @@
+import json
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
+from uuid import UUID
 
 
+@dataclass
 class Location:
-    def __init__(self, x: float, y: float):
-        self.x: float = x
-        self.y: float = y
+    DEFAULT_X = 0.0
+    DEFAULT_Y = 0.0
+
+    x: float = DEFAULT_X
+    y: float = DEFAULT_Y
 
     @classmethod
-    def from_dict(cls, data: dict[str, float]) -> "Location":
-        x = data.get("x", 0.0)
-        y = data.get("y", 0.0)
-        return cls(x=x, y=y)
+    def from_dict(cls, location_data: dict[str, float]) -> "Location":
+        return cls(x=location_data.get("x", cls.DEFAULT_X), y=location_data.get("y", cls.DEFAULT_Y))
+
+    def to_dict(self) -> dict[str, float]:
+        return {"x": self.x, "y": self.y}
 
 
+@dataclass
 class Callout:
-    def __init__(self, callout_data: dict[str, Any]):
-        self.region_name: str = callout_data.get("regionName", "")
-        self.super_region_name: str = callout_data.get("superRegionName", "")
-        self.location: Location = Location.from_dict(callout_data.get("location", {}))
+    region_name: str
+    super_region_name: str | None = None
+    location: Location = field(default_factory=Location)
+
+    @classmethod
+    def from_dict(cls, callout_data: dict[str, Any]) -> "Callout":
+        return cls(
+            region_name=callout_data["regionName"],
+            super_region_name=callout_data.get("superRegionName"),
+            location=Location.from_dict(callout_data.get("location", {})),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "regionName": self.region_name,
+            "superRegionName": self.super_region_name,
+            "location": self.location.to_dict(),
+        }
 
 
-class Map:
-    def __init__(self, map_metadata: dict[str, Any]):
-        self.uuid: str = map_metadata.get("uuid", "")
-        self.display_name: str = map_metadata.get("displayName", "")
-        self.display_icon: str = map_metadata.get("displayIcon", "")
-        self.list_view_icon: str = map_metadata.get("listViewIcon", "")
-        self.splash: str = map_metadata.get("splash", "")
-        self.x_multiplier: float = map_metadata.get("xMultiplier", 1.0)
-        self.y_multiplier: float = map_metadata.get("yMultiplier", 1.0)
-        self.x_scalar_to_add: float = map_metadata.get("xScalarToAdd", 0.0)
-        self.y_scalar_to_add: float = map_metadata.get("yScalarToAdd", 0.0)
+@dataclass
+class GameMap:
+    X_MULTIPLIER = 1.0
+    Y_MULTIPLIER = 1.0
+    X_SCALAR_TO_ADD = 0.0
+    Y_SCALAR_TO_ADD = 0.0
 
+    uuid: UUID
+    display_name: str
+    display_icon: str
+    list_view_icon: str | None = None
+    splash: str | None = None
+    x_multiplier: float = X_MULTIPLIER
+    y_multiplier: float = Y_MULTIPLIER
+    x_scalar_to_add: float = X_SCALAR_TO_ADD
+    y_scalar_to_add: float = Y_SCALAR_TO_ADD
+    callouts: list[Callout] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, map_metadata: dict[str, Any]) -> "GameMap":
         callouts_data = map_metadata.get("callouts", [])
         if callouts_data is None:
             callouts_data = []
-        self.callouts: list[Callout] = [Callout(callout) for callout in callouts_data if callouts_data is not None]
+        return cls(
+            uuid=UUID(map_metadata["uuid"]),
+            display_name=map_metadata["displayName"],
+            display_icon=map_metadata["displayIcon"],
+            list_view_icon=map_metadata.get("listViewIcon"),
+            splash=map_metadata.get("splash"),
+            x_multiplier=map_metadata.get("xMultiplier", cls.X_MULTIPLIER),
+            y_multiplier=map_metadata.get("yMultiplier", cls.Y_MULTIPLIER),
+            x_scalar_to_add=map_metadata.get("xScalarToAdd", cls.X_SCALAR_TO_ADD),
+            y_scalar_to_add=map_metadata.get("yScalarToAdd", cls.Y_SCALAR_TO_ADD),
+            callouts=[Callout.from_dict(callout) for callout in callouts_data],
+        )
+
+    @classmethod
+    def from_json(cls, path: str) -> "GameMap":
+        with open(path) as file:
+            data = json.load(file)
+        return cls.from_dict(data)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "uuid": str(self.uuid),
+            "displayName": self.display_name,
+            "displayIcon": self.display_icon,
+            "listViewIcon": self.list_view_icon,
+            "splash": self.splash,
+            "xMultiplier": self.x_multiplier,
+            "yMultiplier": self.y_multiplier,
+            "xScalarToAdd": self.x_scalar_to_add,
+            "yScalarToAdd": self.y_scalar_to_add,
+            "callouts": [callout.to_dict() for callout in self.callouts],
+        }
+
+    def to_json(self, path: str) -> None:
+        with open(path, "w") as file:
+            json.dump(self.to_dict(), file, indent=4)
 
 
 class MapUUIDs(Enum):
-    ABYSS = "224b0a95-48b9-f703-1bd8-67aca101a61f"
-    ASCENT = "7eaecc1b-4337-bbf6-6ab9-04b8f06b3319"
-    BIND = "2c9d57ec-4431-9c5e-2939-8f9ef6dd5cba"
-    BREEZE = "2fb9a4fd-47b8-4e7d-a969-74b4046ebd53"
-    FRACTURE = "b529448b-4d60-346e-e89e-00a4c527a405"
-    HAVEN = "2bee0dc9-4ffe-519b-1cbd-7fbe763a6047"
-    ICEBOX = "e2ad5c54-4114-a870-9641-8ea21279579a"
-    LOTUS = "2fe4ed3a-450a-948b-6d6b-e89a78e680a9"
-    PEARL = "fd267378-4d1d-484f-ff52-77821ed10dc2"
-    SPLIT = "d960549e-485c-e861-8d71-aa9d1aed12a2"
-    SUNSET = "92584fbe-486a-b1b2-9faa-39b0f486b498"
+    ABYSS = UUID("224b0a95-48b9-f703-1bd8-67aca101a61f")
+    ASCENT = UUID("7eaecc1b-4337-bbf6-6ab9-04b8f06b3319")
+    BIND = UUID("2c9d57ec-4431-9c5e-2939-8f9ef6dd5cba")
+    BREEZE = UUID("2fb9a4fd-47b8-4e7d-a969-74b4046ebd53")
+    FRACTURE = UUID("b529448b-4d60-346e-e89e-00a4c527a405")
+    HAVEN = UUID("2bee0dc9-4ffe-519b-1cbd-7fbe763a6047")
+    ICEBOX = UUID("e2ad5c54-4114-a870-9641-8ea21279579a")
+    LOTUS = UUID("2fe4ed3a-450a-948b-6d6b-e89a78e680a9")
+    PEARL = UUID("fd267378-4d1d-484f-ff52-77821ed10dc2")
+    SPLIT = UUID("d960549e-485c-e861-8d71-aa9d1aed12a2")
+    SUNSET = UUID("92584fbe-486a-b1b2-9faa-39b0f486b498")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,4 +5,4 @@ import pytest
 
 @pytest.fixture()
 def uuid():
-    return str(uuid4())
+    return uuid4()

--- a/tests/models/test_map.py
+++ b/tests/models/test_map.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 import pytest
 
-from src.models.map import Callout, GameMap, Location
+from src.models.game_map import Callout, GameMap, Location
 
 
 @pytest.fixture()

--- a/tests/models/test_map.py
+++ b/tests/models/test_map.py
@@ -1,6 +1,10 @@
+import os
+import tempfile
+from uuid import UUID
+
 import pytest
 
-from src.models.map import Callout, Location, Map
+from src.models.map import Callout, GameMap, Location
 
 
 @pytest.fixture()
@@ -27,7 +31,7 @@ def map_metadata(uuid, callout_data):
     second_callout["location"] = {"x": callout_data["location"]["x"] + 1, "y": callout_data["location"]["y"] + 1}
 
     return {
-        "uuid": uuid,
+        "uuid": str(uuid),
         "displayName": "Test Map",
         "displayIcon": "icon.png",
         "listViewIcon": "list_icon.png",
@@ -42,7 +46,23 @@ def map_metadata(uuid, callout_data):
 
 @pytest.fixture()
 def empty_map_metadata(uuid):
-    return {"uuid": uuid, "displayName": "Test Map"}
+    return {"uuid": str(uuid), "displayName": "Test Map", "displayIcon": "icon.png"}
+
+
+@pytest.fixture()
+def map_metadata_with_null_values(uuid):
+    return {
+        "uuid": str(uuid),
+        "displayName": "Test Map",
+        "displayIcon": "icon.png",
+        "list_view_icon": None,
+        "splash": None,
+        "x_multiplier": None,
+        "y_multiplier": None,
+        "x_scalar_to_add": None,
+        "y_scalar_to_add": None,
+        "callouts": None,
+    }
 
 
 def test_location_from_dict(location_data):
@@ -57,39 +77,112 @@ def test_location_from_empty_dict(empty_location_data):
     assert location.y == 0.0
 
 
-def test_callout_initialization(callout_data):
-    callout = Callout(callout_data)
+def test_location_to_dict(location_data):
+    location = Location.from_dict(location_data)
+    assert location.to_dict() == location_data
+
+
+def test_location_round_trip(location_data):
+    location = Location.from_dict(location_data)
+    location_dict = location.to_dict()
+    assert location == Location.from_dict(location_dict)
+
+
+def test_callout_from_dict_initialization(callout_data):
+    callout = Callout.from_dict(callout_data)
     assert callout.region_name == callout_data["regionName"]
     assert callout.super_region_name == callout_data["superRegionName"]
     assert callout.location.x == callout_data["location"]["x"]
     assert callout.location.y == callout_data["location"]["y"]
 
 
-def test_map_initialization(map_metadata):
-    map_instance = Map(map_metadata)
-    assert map_instance.uuid == map_metadata["uuid"]
-    assert map_instance.display_name == map_metadata["displayName"]
-    assert map_instance.display_icon == map_metadata["displayIcon"]
-    assert map_instance.list_view_icon == map_metadata["listViewIcon"]
-    assert map_instance.splash == map_metadata["splash"]
-    assert map_instance.x_multiplier == map_metadata["xMultiplier"]
-    assert map_instance.y_multiplier == map_metadata["yMultiplier"]
-    assert map_instance.x_scalar_to_add == map_metadata["xScalarToAdd"]
-    assert map_instance.y_scalar_to_add == map_metadata["yScalarToAdd"]
-    assert len(map_instance.callouts) == len(map_metadata["callouts"])
-    assert map_instance.callouts[0].region_name == map_metadata["callouts"][0]["regionName"]
-    assert map_instance.callouts[1].region_name == map_metadata["callouts"][1]["regionName"]
+def test_callout_instantiation_without_region_name_raises_keyerror(location_data):
+    with pytest.raises(KeyError):
+        Callout.from_dict({"superRegionName": "Test Super Region", "location": location_data})
 
 
-def test_map_initialization_with_empty_values(empty_map_metadata):
-    map_instance = Map(empty_map_metadata)
-    assert map_instance.uuid == empty_map_metadata["uuid"]
-    assert map_instance.display_name == empty_map_metadata["displayName"]
-    assert map_instance.display_icon == ""
-    assert map_instance.list_view_icon == ""
-    assert map_instance.splash == ""
-    assert map_instance.x_multiplier == 1.0
-    assert map_instance.y_multiplier == 1.0
-    assert map_instance.x_scalar_to_add == 0.0
-    assert map_instance.x_scalar_to_add == 0.0
-    assert len(map_instance.callouts) == 0
+def test_callout_to_dict(callout_data):
+    callout = Callout.from_dict(callout_data)
+    assert callout.to_dict() == callout_data
+
+
+def test_callout_round_trip(callout_data):
+    callout = Callout.from_dict(callout_data)
+    callout_dict = callout.to_dict()
+    assert callout == Callout.from_dict(callout_dict)
+
+
+def test_map_from_dict_initialization(map_metadata):
+    game_map = GameMap.from_dict(map_metadata)
+    assert game_map.uuid == UUID(map_metadata["uuid"])
+    assert game_map.display_name == map_metadata["displayName"]
+    assert game_map.display_icon == map_metadata["displayIcon"]
+    assert game_map.list_view_icon == map_metadata["listViewIcon"]
+    assert game_map.splash == map_metadata["splash"]
+    assert game_map.x_multiplier == map_metadata["xMultiplier"]
+    assert game_map.y_multiplier == map_metadata["yMultiplier"]
+    assert game_map.x_scalar_to_add == map_metadata["xScalarToAdd"]
+    assert game_map.y_scalar_to_add == map_metadata["yScalarToAdd"]
+    assert len(game_map.callouts) == len(map_metadata["callouts"])
+    assert game_map.callouts[0].region_name == map_metadata["callouts"][0]["regionName"]
+    assert game_map.callouts[1].region_name == map_metadata["callouts"][1]["regionName"]
+
+
+def test_map_from_dict_initialization_with_empty_values(empty_map_metadata):
+    game_map = GameMap.from_dict(empty_map_metadata)
+    assert game_map.uuid == UUID(empty_map_metadata["uuid"])
+    assert game_map.display_name == empty_map_metadata["displayName"]
+    assert game_map.display_icon == "icon.png"
+    assert game_map.list_view_icon is None
+    assert game_map.splash is None
+    assert game_map.x_multiplier == 1.0
+    assert game_map.y_multiplier == 1.0
+    assert game_map.x_scalar_to_add == 0.0
+    assert game_map.x_scalar_to_add == 0.0
+    assert len(game_map.callouts) == 0
+
+
+def test_map_from_dict_initialization_with_null_values(map_metadata_with_null_values):
+    game_map = GameMap.from_dict(map_metadata_with_null_values)
+    assert game_map.uuid == UUID(map_metadata_with_null_values["uuid"])
+    assert game_map.display_name == map_metadata_with_null_values["displayName"]
+    assert game_map.display_icon == map_metadata_with_null_values["displayIcon"]
+    assert game_map.list_view_icon is None
+    assert game_map.splash is None
+    assert game_map.x_multiplier == 1.0
+    assert game_map.y_multiplier == 1.0
+    assert game_map.x_scalar_to_add == 0.0
+    assert game_map.x_scalar_to_add == 0.0
+    assert len(game_map.callouts) == 0
+
+
+@pytest.mark.parametrize("missing_key", ["uuid", "displayName", "displayIcon"])
+def test_map_instantiation_missing_key_raises_keyerror(map_metadata, missing_key):
+    map_metadata_missing_key = map_metadata.copy()
+    del map_metadata_missing_key[missing_key]
+
+    with pytest.raises(KeyError):
+        GameMap.from_dict(map_metadata_missing_key)
+
+
+def test_map_to_dict(map_metadata):
+    game_map = GameMap.from_dict(map_metadata)
+    assert game_map.to_dict() == map_metadata
+
+
+def test_map_round_trip(map_metadata):
+    game_map = GameMap.from_dict(map_metadata)
+    map_dict = game_map.to_dict()
+    assert game_map == GameMap.from_dict(map_dict)
+
+
+def test_map_json_serialization(map_metadata):
+    game_map = GameMap.from_dict(map_metadata)
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_file_path = temp_file.name
+    try:
+        game_map.to_json(temp_file_path)
+        loaded_game_map = GameMap.from_json(temp_file_path)
+        assert game_map == loaded_game_map
+    finally:
+        os.remove(temp_file_path)


### PR DESCRIPTION
Refactoring map models as dataclasses for better maintainability.

Also adding to_dict and to_json methods to be able to store data in src folder