### PR TITLE
Feat/download maps data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v4.4.0
     hooks:
     -   id: pretty-format-json
-        args: [--autofix]
+        args: [--autofix, --no-sort-keys]
     -   id: detect-private-key
     -   id: end-of-file-fixer
     -   id: name-tests-test

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,8 @@ install:  ## Install dev-requirements and pre-commit
 	pre-commit install
 	pre-commit install --hook-type commit-msg
 	@echo "----Done----"
+
+download-data:  ## Downloads maps data from Valorant API
+	@echo "----Downloading maps data----"
+	python download_data.py
+	@echo "----Done----"

--- a/download_data.py
+++ b/download_data.py
@@ -1,0 +1,27 @@
+import os
+from logging import INFO, basicConfig, getLogger
+
+from src.models.game_map import GameMap, MapUUIDs
+from valorant_client.client import ValorantClient
+
+basicConfig(level=INFO)
+logger = getLogger(__name__)
+
+
+if __name__ == "__main__":
+    client = ValorantClient()
+    base_directory = os.path.join("src", "data")
+
+    for map_uuid in MapUUIDs:
+        map_name = map_uuid.name.lower()
+        logger.info(f"Downloading data for {map_name}")
+        try:
+            map_data = client.get_map_by_uuid(map_uuid.value)
+            game_map = GameMap.from_dict(map_data.get("data", {}))
+            file_name = f"{map_name}.json"
+            path = os.path.join(base_directory, "maps", file_name)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            game_map.to_json(path)
+            logger.info(f"Saved map to {path}")
+        except Exception as e:
+            logger.exception(f"Error downloading data for {map_name}: {e}")

--- a/src/data/maps/abyss.json
+++ b/src/data/maps/abyss.json
@@ -1,0 +1,197 @@
+{
+  "uuid": "224b0a95-48b9-f703-1bd8-67aca101a61f",
+  "displayName": "Abyss",
+  "displayIcon": "https://media.valorant-api.com/maps/224b0a95-48b9-f703-1bd8-67aca101a61f/displayicon.png",
+  "listViewIcon": "https://media.valorant-api.com/maps/224b0a95-48b9-f703-1bd8-67aca101a61f/listviewicon.png",
+  "splash": "https://media.valorant-api.com/maps/224b0a95-48b9-f703-1bd8-67aca101a61f/splash.png",
+  "xMultiplier": 8.1e-05,
+  "yMultiplier": -8.1e-05,
+  "xScalarToAdd": 0.5,
+  "yScalarToAdd": 0.5,
+  "callouts": [
+    {
+      "regionName": "Bridge",
+      "superRegionName": "A",
+      "location": {
+        "x": 5700,
+        "y": -375
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "A",
+      "location": {
+        "x": 2800,
+        "y": -2450
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "A",
+      "location": {
+        "x": 3250,
+        "y": 3400
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "A",
+      "location": {
+        "x": 3800,
+        "y": 1650
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "A",
+      "location": {
+        "x": 4300,
+        "y": -200
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": 950,
+        "y": 4950
+      }
+    },
+    {
+      "regionName": "Tower",
+      "superRegionName": "A",
+      "location": {
+        "x": 3025,
+        "y": -125
+      }
+    },
+    {
+      "regionName": "Bend",
+      "superRegionName": "Mid",
+      "location": {
+        "x": -1700,
+        "y": 1950
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "B",
+      "location": {
+        "x": -2000,
+        "y": -2350
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "B",
+      "location": {
+        "x": -3650,
+        "y": 4025
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "B",
+      "location": {
+        "x": -4450,
+        "y": 1525
+      }
+    },
+    {
+      "regionName": "Nest",
+      "superRegionName": "B",
+      "location": {
+        "x": -4975,
+        "y": 2150
+      }
+    },
+    {
+      "regionName": "Bottom",
+      "superRegionName": "Mid",
+      "location": {
+        "x": -400,
+        "y": 575
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "B",
+      "location": {
+        "x": -4425,
+        "y": -1175
+      }
+    },
+    {
+      "regionName": "Catwalk",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 600,
+        "y": 525
+      }
+    },
+    {
+      "regionName": "Danger",
+      "superRegionName": "B",
+      "location": {
+        "x": -5850,
+        "y": 700
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 950,
+        "y": -5275
+      }
+    },
+    {
+      "regionName": "Library",
+      "superRegionName": "Mid",
+      "location": {
+        "x": -325,
+        "y": -600
+      }
+    },
+    {
+      "regionName": "Secret",
+      "superRegionName": "A",
+      "location": {
+        "x": 3775,
+        "y": -3850
+      }
+    },
+    {
+      "regionName": "Security",
+      "superRegionName": "A",
+      "location": {
+        "x": 4900,
+        "y": -2975
+      }
+    },
+    {
+      "regionName": "Top",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 775,
+        "y": -2375
+      }
+    },
+    {
+      "regionName": "Tower",
+      "superRegionName": "B",
+      "location": {
+        "x": -3925,
+        "y": -2500
+      }
+    },
+    {
+      "regionName": "Vent",
+      "superRegionName": "A",
+      "location": {
+        "x": 1700,
+        "y": -325
+      }
+    }
+  ]
+}

--- a/src/data/maps/ascent.json
+++ b/src/data/maps/ascent.json
@@ -1,0 +1,189 @@
+{
+  "uuid": "7eaecc1b-4337-bbf6-6ab9-04b8f06b3319",
+  "displayName": "Ascent",
+  "displayIcon": "https://media.valorant-api.com/maps/7eaecc1b-4337-bbf6-6ab9-04b8f06b3319/displayicon.png",
+  "listViewIcon": "https://media.valorant-api.com/maps/7eaecc1b-4337-bbf6-6ab9-04b8f06b3319/listviewicon.png",
+  "splash": "https://media.valorant-api.com/maps/7eaecc1b-4337-bbf6-6ab9-04b8f06b3319/splash.png",
+  "xMultiplier": 7e-05,
+  "yMultiplier": -7e-05,
+  "xScalarToAdd": 0.813895,
+  "yScalarToAdd": 0.573242,
+  "callouts": [
+    {
+      "regionName": "Tree",
+      "superRegionName": "A",
+      "location": {
+        "x": 3980.9062,
+        "y": -5938.758
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "A",
+      "location": {
+        "x": 4489.032,
+        "y": -3014.0515
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "A",
+      "location": {
+        "x": 5321.6206,
+        "y": -4710.1274
+      }
+    },
+    {
+      "regionName": "Window",
+      "superRegionName": "A",
+      "location": {
+        "x": 4023.0244,
+        "y": -8180.692
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "A",
+      "location": {
+        "x": 6153.585,
+        "y": -6626.2114
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": 60,
+        "y": 50
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "B",
+      "location": {
+        "x": -1490.5864,
+        "y": -1389.9706
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "B",
+      "location": {
+        "x": -1983.6713,
+        "y": -5840.8125
+      }
+    },
+    {
+      "regionName": "Boat House",
+      "superRegionName": "B",
+      "location": {
+        "x": -4484.774,
+        "y": -7763.3584
+      }
+    },
+    {
+      "regionName": "Bottom",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 1122.2262,
+        "y": -5951.704
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "B",
+      "location": {
+        "x": -2344.065,
+        "y": -7548.511
+      }
+    },
+    {
+      "regionName": "Catwalk",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 2315.7944,
+        "y": -4127.2554
+      }
+    },
+    {
+      "regionName": "Cubby",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 3387.3167,
+        "y": -5129.764
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 1995.2354,
+        "y": -9744.923
+      }
+    },
+    {
+      "regionName": "Garden",
+      "superRegionName": "A",
+      "location": {
+        "x": 3773.6653,
+        "y": -7551.3535
+      }
+    },
+    {
+      "regionName": "Market",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 1089.1044,
+        "y": -7363.1914
+      }
+    },
+    {
+      "regionName": "Courtyard",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 1222.7029,
+        "y": -4586.6
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "Mid",
+      "location": {
+        "x": -632.0929,
+        "y": -4280.2573
+      }
+    },
+    {
+      "regionName": "Pizza",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 1801.5667,
+        "y": -7262.1704
+      }
+    },
+    {
+      "regionName": "Rafters",
+      "superRegionName": "A",
+      "location": {
+        "x": 6129.893,
+        "y": -8210
+      }
+    },
+    {
+      "regionName": "Top",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 2753.9297,
+        "y": -2129.6155
+      }
+    },
+    {
+      "regionName": "Wine",
+      "superRegionName": "A",
+      "location": {
+        "x": 7358.7407,
+        "y": -4689.2705
+      }
+    }
+  ]
+}

--- a/src/data/maps/bind.json
+++ b/src/data/maps/bind.json
@@ -1,0 +1,205 @@
+{
+  "uuid": "2c9d57ec-4431-9c5e-2939-8f9ef6dd5cba",
+  "displayName": "Bind",
+  "displayIcon": "https://media.valorant-api.com/maps/2c9d57ec-4431-9c5e-2939-8f9ef6dd5cba/displayicon.png",
+  "listViewIcon": "https://media.valorant-api.com/maps/2c9d57ec-4431-9c5e-2939-8f9ef6dd5cba/listviewicon.png",
+  "splash": "https://media.valorant-api.com/maps/2c9d57ec-4431-9c5e-2939-8f9ef6dd5cba/splash.png",
+  "xMultiplier": 5.9e-05,
+  "yMultiplier": -5.9e-05,
+  "xScalarToAdd": 0.576941,
+  "yScalarToAdd": 0.967566,
+  "callouts": [
+    {
+      "regionName": "Exit",
+      "superRegionName": "A",
+      "location": {
+        "x": 7550.4106,
+        "y": 5874.497
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "A",
+      "location": {
+        "x": 6365.635,
+        "y": -1007.0208
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "A",
+      "location": {
+        "x": 6113.239,
+        "y": 3158.823
+      }
+    },
+    {
+      "regionName": "Short",
+      "superRegionName": "A",
+      "location": {
+        "x": 7983.3467,
+        "y": 803.96063
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "A",
+      "location": {
+        "x": 10747.902,
+        "y": 2664.4436
+      }
+    },
+    {
+      "regionName": "Teleporter",
+      "superRegionName": "A",
+      "location": {
+        "x": 9432.303,
+        "y": 489.8803
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": 161.64832,
+        "y": 77.51108
+      }
+    },
+    {
+      "regionName": "Exit",
+      "superRegionName": "B",
+      "location": {
+        "x": 8921.412,
+        "y": -1763.2295
+      }
+    },
+    {
+      "regionName": "Hall",
+      "superRegionName": "B",
+      "location": {
+        "x": 12981.879,
+        "y": -4941.7544
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "B",
+      "location": {
+        "x": 6361.57,
+        "y": -2621.1829
+      }
+    },
+    {
+      "regionName": "Fountain",
+      "superRegionName": "B",
+      "location": {
+        "x": 5737.1484,
+        "y": -5390.446
+      }
+    },
+    {
+      "regionName": "Long",
+      "superRegionName": "B",
+      "location": {
+        "x": 7666.669,
+        "y": -6512.8022
+      }
+    },
+    {
+      "regionName": "Short",
+      "superRegionName": "B",
+      "location": {
+        "x": 7424.1313,
+        "y": -3056.4531
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "B",
+      "location": {
+        "x": 11108.108,
+        "y": -4831.4585
+      }
+    },
+    {
+      "regionName": "Teleporter",
+      "superRegionName": "B",
+      "location": {
+        "x": 9027.776,
+        "y": -7223.8066
+      }
+    },
+    {
+      "regionName": "Window",
+      "superRegionName": "B",
+      "location": {
+        "x": 8826.788,
+        "y": -4309.4116
+      }
+    },
+    {
+      "regionName": "Bath",
+      "superRegionName": "A",
+      "location": {
+        "x": 9106.541,
+        "y": 4449.6587
+      }
+    },
+    {
+      "regionName": "Cave",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": 3920.3887,
+        "y": 256.94193
+      }
+    },
+    {
+      "regionName": "Cubby",
+      "superRegionName": "A",
+      "location": {
+        "x": 8605.168,
+        "y": 174.89832
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 14641.918,
+        "y": -1017.6743
+      }
+    },
+    {
+      "regionName": "Elbow",
+      "superRegionName": "B",
+      "location": {
+        "x": 11212.901,
+        "y": -7095.3335
+      }
+    },
+    {
+      "regionName": "Garden",
+      "superRegionName": "B",
+      "location": {
+        "x": 9144.103,
+        "y": -5598.1274
+      }
+    },
+    {
+      "regionName": "Lamps",
+      "superRegionName": "A",
+      "location": {
+        "x": 10649.471,
+        "y": 79.904434
+      }
+    },
+    {
+      "regionName": "Tower",
+      "superRegionName": "A",
+      "location": {
+        "x": 12872.583,
+        "y": 2556.7708
+      }
+    }
+  ]
+}

--- a/src/data/maps/breeze.json
+++ b/src/data/maps/breeze.json
@@ -1,0 +1,229 @@
+{
+  "uuid": "2fb9a4fd-47b8-4e7d-a969-74b4046ebd53",
+  "displayName": "Breeze",
+  "displayIcon": "https://media.valorant-api.com/maps/2fb9a4fd-47b8-4e7d-a969-74b4046ebd53/displayicon.png",
+  "listViewIcon": "https://media.valorant-api.com/maps/2fb9a4fd-47b8-4e7d-a969-74b4046ebd53/listviewicon.png",
+  "splash": "https://media.valorant-api.com/maps/2fb9a4fd-47b8-4e7d-a969-74b4046ebd53/splash.png",
+  "xMultiplier": 7e-05,
+  "yMultiplier": -7e-05,
+  "xScalarToAdd": 0.465123,
+  "yScalarToAdd": 0.833078,
+  "callouts": [
+    {
+      "regionName": "Hall",
+      "superRegionName": "A",
+      "location": {
+        "x": 4825,
+        "y": 2550
+      }
+    },
+    {
+      "regionName": "Bridge",
+      "superRegionName": "A",
+      "location": {
+        "x": 8400,
+        "y": 3525
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 8900,
+        "y": 3525
+      }
+    },
+    {
+      "regionName": "Arches",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 9400,
+        "y": -1300
+      }
+    },
+    {
+      "regionName": "Wood Doors",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 4825,
+        "y": 2550
+      }
+    },
+    {
+      "regionName": "Pillar",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 4175,
+        "y": 475
+      }
+    },
+    {
+      "regionName": "Top",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 6175,
+        "y": 525
+      }
+    },
+    {
+      "regionName": "Nest",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 8650,
+        "y": 275
+      }
+    },
+    {
+      "regionName": "Window",
+      "superRegionName": "B",
+      "location": {
+        "x": 2225,
+        "y": -4175
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "B",
+      "location": {
+        "x": 3550,
+        "y": -4450
+      }
+    },
+    {
+      "regionName": "Snake",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": 550,
+        "y": -2450
+      }
+    },
+    {
+      "regionName": "Elbow",
+      "superRegionName": "B",
+      "location": {
+        "x": 4675,
+        "y": -2900
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "B",
+      "location": {
+        "x": 6450,
+        "y": -5650
+      }
+    },
+    {
+      "regionName": "Tunnel",
+      "superRegionName": "B",
+      "location": {
+        "x": 6450,
+        "y": -1450
+      }
+    },
+    {
+      "regionName": "Switch",
+      "superRegionName": "A",
+      "location": {
+        "x": 6425,
+        "y": 3050
+      }
+    },
+    {
+      "regionName": "Chute",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 3875,
+        "y": 1800
+      }
+    },
+    {
+      "regionName": "Back",
+      "superRegionName": "B",
+      "location": {
+        "x": 7550,
+        "y": -5675
+      }
+    },
+    {
+      "regionName": "Wall",
+      "superRegionName": "B",
+      "location": {
+        "x": 8550,
+        "y": -3000
+      }
+    },
+    {
+      "regionName": "Rope",
+      "superRegionName": "A",
+      "location": {
+        "x": 3100,
+        "y": 2550
+      }
+    },
+    {
+      "regionName": "Cannon",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 2900,
+        "y": -1850
+      }
+    },
+    {
+      "regionName": "Metal Doors",
+      "superRegionName": "A",
+      "location": {
+        "x": 6825,
+        "y": 2550
+      }
+    },
+    {
+      "regionName": "Bottom",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 1575,
+        "y": 475
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "A",
+      "location": {
+        "x": -1250,
+        "y": 3400
+      }
+    },
+    {
+      "regionName": "Shop",
+      "superRegionName": "A",
+      "location": {
+        "x": 2150,
+        "y": 4250
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "A",
+      "location": {
+        "x": 4825,
+        "y": 6325
+      }
+    },
+    {
+      "regionName": "Pyramids",
+      "superRegionName": "A",
+      "location": {
+        "x": 5200,
+        "y": 5450
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": -575,
+        "y": -450
+      }
+    }
+  ]
+}

--- a/src/data/maps/fracture.json
+++ b/src/data/maps/fracture.json
@@ -1,0 +1,189 @@
+{
+  "uuid": "b529448b-4d60-346e-e89e-00a4c527a405",
+  "displayName": "Fracture",
+  "displayIcon": "https://media.valorant-api.com/maps/b529448b-4d60-346e-e89e-00a4c527a405/displayicon.png",
+  "listViewIcon": "https://media.valorant-api.com/maps/b529448b-4d60-346e-e89e-00a4c527a405/listviewicon.png",
+  "splash": "https://media.valorant-api.com/maps/b529448b-4d60-346e-e89e-00a4c527a405/splash.png",
+  "xMultiplier": 7.8e-05,
+  "yMultiplier": -7.8e-05,
+  "xScalarToAdd": 0.556952,
+  "yScalarToAdd": 1.155886,
+  "callouts": [
+    {
+      "regionName": "Bridge",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": 13204,
+        "y": -756
+      }
+    },
+    {
+      "regionName": "Bench",
+      "superRegionName": "B",
+      "location": {
+        "x": 11473,
+        "y": -2897
+      }
+    },
+    {
+      "regionName": "Arcade",
+      "superRegionName": "B",
+      "location": {
+        "x": 10181,
+        "y": -4179
+      }
+    },
+    {
+      "regionName": "Tower",
+      "superRegionName": "B",
+      "location": {
+        "x": 9155,
+        "y": -5601
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "B",
+      "location": {
+        "x": 8178,
+        "y": -5942
+      }
+    },
+    {
+      "regionName": "Generator",
+      "superRegionName": "B",
+      "location": {
+        "x": 8362,
+        "y": -3380
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "B",
+      "location": {
+        "x": 9198,
+        "y": -2741
+      }
+    },
+    {
+      "regionName": "Canteen",
+      "superRegionName": "B",
+      "location": {
+        "x": 7111,
+        "y": -3138
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "A",
+      "location": {
+        "x": 8578,
+        "y": 1302
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 9156,
+        "y": -677
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "B",
+      "location": {
+        "x": 5967,
+        "y": -5343
+      }
+    },
+    {
+      "regionName": "Tree",
+      "superRegionName": "B",
+      "location": {
+        "x": 4965,
+        "y": -4109
+      }
+    },
+    {
+      "regionName": "Tunnel",
+      "superRegionName": "B",
+      "location": {
+        "x": 7402,
+        "y": -4058
+      }
+    },
+    {
+      "regionName": "Hall",
+      "superRegionName": "A",
+      "location": {
+        "x": 5063.5464,
+        "y": 2057.6648
+      }
+    },
+    {
+      "regionName": "Door",
+      "superRegionName": "A",
+      "location": {
+        "x": 5807.855,
+        "y": 1940.4603
+      }
+    },
+    {
+      "regionName": "Rope",
+      "superRegionName": "A",
+      "location": {
+        "x": 6638.828,
+        "y": 1052.6461
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "A",
+      "location": {
+        "x": 5878.792,
+        "y": 3450.9639
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "A",
+      "location": {
+        "x": 8125.7627,
+        "y": 3373.7861
+      }
+    },
+    {
+      "regionName": "Drop",
+      "superRegionName": "A",
+      "location": {
+        "x": 9306.803,
+        "y": 2826.1626
+      }
+    },
+    {
+      "regionName": "Dish",
+      "superRegionName": "A",
+      "location": {
+        "x": 11296.665,
+        "y": 1391.7144
+      }
+    },
+    {
+      "regionName": "Gate",
+      "superRegionName": "A",
+      "location": {
+        "x": 12962,
+        "y": 1565
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": 4345.554,
+        "y": -948.4505
+      }
+    }
+  ]
+}

--- a/src/data/maps/haven.json
+++ b/src/data/maps/haven.json
@@ -1,0 +1,181 @@
+{
+  "uuid": "2bee0dc9-4ffe-519b-1cbd-7fbe763a6047",
+  "displayName": "Haven",
+  "displayIcon": "https://media.valorant-api.com/maps/2bee0dc9-4ffe-519b-1cbd-7fbe763a6047/displayicon.png",
+  "listViewIcon": "https://media.valorant-api.com/maps/2bee0dc9-4ffe-519b-1cbd-7fbe763a6047/listviewicon.png",
+  "splash": "https://media.valorant-api.com/maps/2bee0dc9-4ffe-519b-1cbd-7fbe763a6047/splash.png",
+  "xMultiplier": 7.5e-05,
+  "yMultiplier": -7.5e-05,
+  "xScalarToAdd": 1.09345,
+  "yScalarToAdd": 0.642728,
+  "callouts": [
+    {
+      "regionName": "Garden",
+      "superRegionName": "A",
+      "location": {
+        "x": 3100.261,
+        "y": -4683.6016
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "A",
+      "location": {
+        "x": 4244.4214,
+        "y": -10715.68
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "A",
+      "location": {
+        "x": 3438.537,
+        "y": -6260.409
+      }
+    },
+    {
+      "regionName": "Long",
+      "superRegionName": "A",
+      "location": {
+        "x": 6209.695,
+        "y": -6901.142
+      }
+    },
+    {
+      "regionName": "Sewer",
+      "superRegionName": "A",
+      "location": {
+        "x": 3452.8735,
+        "y": -7915.7246
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "A",
+      "location": {
+        "x": 6309.3076,
+        "y": -9225.703
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": 1741.7622,
+        "y": -2642.7925
+      }
+    },
+    {
+      "regionName": "Back",
+      "superRegionName": "B",
+      "location": {
+        "x": 1966.1608,
+        "y": -10664.775
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "B",
+      "location": {
+        "x": 1884.706,
+        "y": -9231.335
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "C",
+      "location": {
+        "x": -87.761444,
+        "y": -10004.415
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "C",
+      "location": {
+        "x": -1642.189,
+        "y": -5720.345
+      }
+    },
+    {
+      "regionName": "Long",
+      "superRegionName": "C",
+      "location": {
+        "x": -3356.814,
+        "y": -5990.872
+      }
+    },
+    {
+      "regionName": "Garage",
+      "superRegionName": "C",
+      "location": {
+        "x": 180.07678,
+        "y": -7999.5845
+      }
+    },
+    {
+      "regionName": "Window",
+      "superRegionName": "C",
+      "location": {
+        "x": -10.126678,
+        "y": -8993.241
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "C",
+      "location": {
+        "x": -2378.1328,
+        "y": -9010.557
+      }
+    },
+    {
+      "regionName": "Cubby",
+      "superRegionName": "C",
+      "location": {
+        "x": -2119.7693,
+        "y": -6561.603
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 2946.3042,
+        "y": -12714.707
+      }
+    },
+    {
+      "regionName": "Doors",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 151.11594,
+        "y": -6262.9155
+      }
+    },
+    {
+      "regionName": "Courtyard",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 1822.1299,
+        "y": -6712.6875
+      }
+    },
+    {
+      "regionName": "Window",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 1950.2218,
+        "y": -5567.912
+      }
+    },
+    {
+      "regionName": "Tower",
+      "superRegionName": "A",
+      "location": {
+        "x": 6721.4043,
+        "y": -10472.5205
+      }
+    }
+  ]
+}

--- a/src/data/maps/icebox.json
+++ b/src/data/maps/icebox.json
@@ -1,0 +1,213 @@
+{
+  "uuid": "e2ad5c54-4114-a870-9641-8ea21279579a",
+  "displayName": "Icebox",
+  "displayIcon": "https://media.valorant-api.com/maps/e2ad5c54-4114-a870-9641-8ea21279579a/displayicon.png",
+  "listViewIcon": "https://media.valorant-api.com/maps/e2ad5c54-4114-a870-9641-8ea21279579a/listviewicon.png",
+  "splash": "https://media.valorant-api.com/maps/e2ad5c54-4114-a870-9641-8ea21279579a/splash.png",
+  "xMultiplier": 7.2e-05,
+  "yMultiplier": -7.2e-05,
+  "xScalarToAdd": 0.460214,
+  "yScalarToAdd": 0.304687,
+  "callouts": [
+    {
+      "regionName": "Garage",
+      "superRegionName": "B",
+      "location": {
+        "x": -1250,
+        "y": -1425
+      }
+    },
+    {
+      "regionName": "Belt",
+      "superRegionName": "A",
+      "location": {
+        "x": -7200,
+        "y": -850
+      }
+    },
+    {
+      "regionName": "Nest",
+      "superRegionName": "A",
+      "location": {
+        "x": -6650,
+        "y": 900
+      }
+    },
+    {
+      "regionName": "Pipes",
+      "superRegionName": "A",
+      "location": {
+        "x": -6150,
+        "y": 450
+      }
+    },
+    {
+      "regionName": "Rafters",
+      "superRegionName": "A",
+      "location": {
+        "x": -6450,
+        "y": 4250
+      }
+    },
+    {
+      "regionName": "Screen",
+      "superRegionName": "A",
+      "location": {
+        "x": -5100,
+        "y": 3325
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "A",
+      "location": {
+        "x": -6400,
+        "y": 3200
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": -3925,
+        "y": -4450
+      }
+    },
+    {
+      "regionName": "Yellow",
+      "superRegionName": "B",
+      "location": {
+        "x": 2050,
+        "y": -25
+      }
+    },
+    {
+      "regionName": "Back",
+      "superRegionName": "B",
+      "location": {
+        "x": 251,
+        "y": 4269
+      }
+    },
+    {
+      "regionName": "Cubby",
+      "superRegionName": "B",
+      "location": {
+        "x": 1050,
+        "y": -975
+      }
+    },
+    {
+      "regionName": "Green",
+      "superRegionName": "B",
+      "location": {
+        "x": -450,
+        "y": -700
+      }
+    },
+    {
+      "regionName": "Hall",
+      "superRegionName": "B",
+      "location": {
+        "x": 300,
+        "y": 3050
+      }
+    },
+    {
+      "regionName": "Hut",
+      "superRegionName": "B",
+      "location": {
+        "x": -1425,
+        "y": 4400
+      }
+    },
+    {
+      "regionName": "Kitchen",
+      "superRegionName": "B",
+      "location": {
+        "x": -2221.3618,
+        "y": 3403.649
+      }
+    },
+    {
+      "regionName": "Orange",
+      "superRegionName": "B",
+      "location": {
+        "x": -632,
+        "y": 1700
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "B",
+      "location": {
+        "x": 1725,
+        "y": 2575
+      }
+    },
+    {
+      "regionName": "Snowman",
+      "superRegionName": "B",
+      "location": {
+        "x": 2250,
+        "y": 3960.3218
+      }
+    },
+    {
+      "regionName": "Snow Pile",
+      "superRegionName": "B",
+      "location": {
+        "x": -1775,
+        "y": 2500
+      }
+    },
+    {
+      "regionName": "Tube",
+      "superRegionName": "B",
+      "location": {
+        "x": -2300,
+        "y": 1275
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": -3750,
+        "y": 7075
+      }
+    },
+    {
+      "regionName": "Blue",
+      "superRegionName": "Mid",
+      "location": {
+        "x": -2825,
+        "y": 975
+      }
+    },
+    {
+      "regionName": "Boiler",
+      "superRegionName": "Mid",
+      "location": {
+        "x": -3375,
+        "y": 2925
+      }
+    },
+    {
+      "regionName": "Pallet",
+      "superRegionName": "Mid",
+      "location": {
+        "x": -4450,
+        "y": 1775
+      }
+    },
+    {
+      "regionName": "Fence",
+      "superRegionName": "B",
+      "location": {
+        "x": 363,
+        "y": 3595
+      }
+    }
+  ]
+}

--- a/src/data/maps/lotus.json
+++ b/src/data/maps/lotus.json
@@ -1,0 +1,237 @@
+{
+  "uuid": "2fe4ed3a-450a-948b-6d6b-e89a78e680a9",
+  "displayName": "Lotus",
+  "displayIcon": "https://media.valorant-api.com/maps/2fe4ed3a-450a-948b-6d6b-e89a78e680a9/displayicon.png",
+  "listViewIcon": "https://media.valorant-api.com/maps/2fe4ed3a-450a-948b-6d6b-e89a78e680a9/listviewicon.png",
+  "splash": "https://media.valorant-api.com/maps/2fe4ed3a-450a-948b-6d6b-e89a78e680a9/splash.png",
+  "xMultiplier": 7.2e-05,
+  "yMultiplier": -7.2e-05,
+  "xScalarToAdd": 0.454789,
+  "yScalarToAdd": 0.917752,
+  "callouts": [
+    {
+      "regionName": "Top",
+      "superRegionName": "A",
+      "location": {
+        "x": 9260.3,
+        "y": 5045.5884
+      }
+    },
+    {
+      "regionName": "Drop",
+      "superRegionName": "A",
+      "location": {
+        "x": 9516.38,
+        "y": 6092.8936
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "A",
+      "location": {
+        "x": 7735.5396,
+        "y": 5557.309
+      }
+    },
+    {
+      "regionName": "Hut",
+      "superRegionName": "A",
+      "location": {
+        "x": 7917.4614,
+        "y": 5557.309
+      }
+    },
+    {
+      "regionName": "Tree",
+      "superRegionName": "A",
+      "location": {
+        "x": 6149.525,
+        "y": 5557.309
+      }
+    },
+    {
+      "regionName": "Door",
+      "superRegionName": "A",
+      "location": {
+        "x": 5608.7563,
+        "y": 5203.91
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "A",
+      "location": {
+        "x": 5288.3022,
+        "y": 4159.762
+      }
+    },
+    {
+      "regionName": "Rubble",
+      "superRegionName": "A",
+      "location": {
+        "x": 4401.0713,
+        "y": 4918.189
+      }
+    },
+    {
+      "regionName": "Root",
+      "superRegionName": "A",
+      "location": {
+        "x": 4401.0713,
+        "y": 3294.1523
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "A",
+      "location": {
+        "x": 2685.951,
+        "y": 2927.1755
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "C",
+      "location": {
+        "x": 1403.5685,
+        "y": -1576.5884
+      }
+    },
+    {
+      "regionName": "Pillars",
+      "superRegionName": "B",
+      "location": {
+        "x": 3565.3691,
+        "y": 668.18317
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "B",
+      "location": {
+        "x": 4876.832,
+        "y": -47.87195
+      }
+    },
+    {
+      "regionName": "Door",
+      "superRegionName": "C",
+      "location": {
+        "x": 4818.6655,
+        "y": -1752.8021
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "B",
+      "location": {
+        "x": 6368.0327,
+        "y": 668.18317
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "A",
+      "location": {
+        "x": 6011.0664,
+        "y": 2087.6528
+      }
+    },
+    {
+      "regionName": "Upper",
+      "superRegionName": "B",
+      "location": {
+        "x": 7682.943,
+        "y": 1517.3606
+      }
+    },
+    {
+      "regionName": "Waterfall",
+      "superRegionName": "C",
+      "location": {
+        "x": 6719.804,
+        "y": -1994.2986
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "C",
+      "location": {
+        "x": 7504.109,
+        "y": -1377.893
+      }
+    },
+    {
+      "regionName": "Stairs",
+      "superRegionName": "A",
+      "location": {
+        "x": 8257.875,
+        "y": 3860.9312
+      }
+    },
+    {
+      "regionName": "Mound",
+      "superRegionName": "C",
+      "location": {
+        "x": 3863.7183,
+        "y": -1576.5884
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "C",
+      "location": {
+        "x": 5311.2646,
+        "y": -3148.162
+      }
+    },
+    {
+      "regionName": "Bend",
+      "superRegionName": "C",
+      "location": {
+        "x": 5657.522,
+        "y": -5281.4395
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "C",
+      "location": {
+        "x": 6676.6636,
+        "y": -4265.876
+      }
+    },
+    {
+      "regionName": "Hall",
+      "superRegionName": "C",
+      "location": {
+        "x": 7902.0615,
+        "y": -4265.876
+      }
+    },
+    {
+      "regionName": "Gravel",
+      "superRegionName": "C",
+      "location": {
+        "x": 8936.881,
+        "y": -1752.2874
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 9686.767,
+        "y": 1697.8223
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": 1401.2915,
+        "y": 777.29834
+      }
+    }
+  ]
+}

--- a/src/data/maps/pearl.json
+++ b/src/data/maps/pearl.json
@@ -1,0 +1,221 @@
+{
+  "uuid": "fd267378-4d1d-484f-ff52-77821ed10dc2",
+  "displayName": "Pearl",
+  "displayIcon": "https://media.valorant-api.com/maps/fd267378-4d1d-484f-ff52-77821ed10dc2/displayicon.png",
+  "listViewIcon": "https://media.valorant-api.com/maps/fd267378-4d1d-484f-ff52-77821ed10dc2/listviewicon.png",
+  "splash": "https://media.valorant-api.com/maps/fd267378-4d1d-484f-ff52-77821ed10dc2/splash.png",
+  "xMultiplier": 7.8e-05,
+  "yMultiplier": -7.8e-05,
+  "xScalarToAdd": 0.480469,
+  "yScalarToAdd": 0.916016,
+  "callouts": [
+    {
+      "regionName": "Hall",
+      "superRegionName": "B",
+      "location": {
+        "x": 7495.6177,
+        "y": -4954.14
+      }
+    },
+    {
+      "regionName": "Doors",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 4701.24,
+        "y": 597.23285
+      }
+    },
+    {
+      "regionName": "Connector",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 6047.0464,
+        "y": 1800.0436
+      }
+    },
+    {
+      "regionName": "Water",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 7808.019,
+        "y": 1800.0419
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 11092.458,
+        "y": 378.79883
+      }
+    },
+    {
+      "regionName": "Flowers",
+      "superRegionName": "A",
+      "location": {
+        "x": 9263.969,
+        "y": 2507.3403
+      }
+    },
+    {
+      "regionName": "Secret",
+      "superRegionName": "A",
+      "location": {
+        "x": 10458.144,
+        "y": 3831.5127
+      }
+    },
+    {
+      "regionName": "Dugout",
+      "superRegionName": "A",
+      "location": {
+        "x": 7660.6597,
+        "y": 5854.0664
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "A",
+      "location": {
+        "x": 6613.846,
+        "y": 5569.5254
+      }
+    },
+    {
+      "regionName": "Records",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 8973.152,
+        "y": -1470.2677
+      }
+    },
+    {
+      "regionName": "Top",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 2075,
+        "y": 725
+      }
+    },
+    {
+      "regionName": "Tunnel",
+      "superRegionName": "B",
+      "location": {
+        "x": 8973.152,
+        "y": -2155.1323
+      }
+    },
+    {
+      "regionName": "Tower",
+      "superRegionName": "B",
+      "location": {
+        "x": 8533.423,
+        "y": -2851.3516
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "A",
+      "location": {
+        "x": 6368.5713,
+        "y": 3825
+      }
+    },
+    {
+      "regionName": "Restaurant",
+      "superRegionName": "A",
+      "location": {
+        "x": 4430.452,
+        "y": 2813.1267
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "B",
+      "location": {
+        "x": 4503.3633,
+        "y": -591.64435
+      }
+    },
+    {
+      "regionName": "Art",
+      "superRegionName": "A",
+      "location": {
+        "x": 4561.95,
+        "y": 3406.8806
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "A",
+      "location": {
+        "x": 6055.2104,
+        "y": 3782.704
+      }
+    },
+    {
+      "regionName": "Plaza",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 2750,
+        "y": -325
+      }
+    },
+    {
+      "regionName": "Shops",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 800,
+        "y": -1450
+      }
+    },
+    {
+      "regionName": "Club",
+      "superRegionName": "B",
+      "location": {
+        "x": 800,
+        "y": -1450
+      }
+    },
+    {
+      "regionName": "Ramp",
+      "superRegionName": "B",
+      "location": {
+        "x": 1750,
+        "y": -3800
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "B",
+      "location": {
+        "x": 4050,
+        "y": -4375
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "B",
+      "location": {
+        "x": 5800,
+        "y": -2850
+      }
+    },
+    {
+      "regionName": "Screen",
+      "superRegionName": "B",
+      "location": {
+        "x": 6260.4326,
+        "y": -5000.933
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": -550,
+        "y": -600
+      }
+    }
+  ]
+}

--- a/src/data/maps/split.json
+++ b/src/data/maps/split.json
@@ -1,0 +1,205 @@
+{
+  "uuid": "d960549e-485c-e861-8d71-aa9d1aed12a2",
+  "displayName": "Split",
+  "displayIcon": "https://media.valorant-api.com/maps/d960549e-485c-e861-8d71-aa9d1aed12a2/displayicon.png",
+  "listViewIcon": "https://media.valorant-api.com/maps/d960549e-485c-e861-8d71-aa9d1aed12a2/listviewicon.png",
+  "splash": "https://media.valorant-api.com/maps/d960549e-485c-e861-8d71-aa9d1aed12a2/splash.png",
+  "xMultiplier": 7.8e-05,
+  "yMultiplier": -7.8e-05,
+  "xScalarToAdd": 0.842188,
+  "yScalarToAdd": 0.697578,
+  "callouts": [
+    {
+      "regionName": "Back",
+      "superRegionName": "A",
+      "location": {
+        "x": 7345.049,
+        "y": -7858.0405
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "A",
+      "location": {
+        "x": 6814.217,
+        "y": -2457.7468
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "A",
+      "location": {
+        "x": 6279.9795,
+        "y": -4492.833
+      }
+    },
+    {
+      "regionName": "Rafters",
+      "superRegionName": "A",
+      "location": {
+        "x": 5434.726,
+        "y": -6258.442
+      }
+    },
+    {
+      "regionName": "Ramps",
+      "superRegionName": "A",
+      "location": {
+        "x": 4330,
+        "y": -4750
+      }
+    },
+    {
+      "regionName": "Screens",
+      "superRegionName": "A",
+      "location": {
+        "x": 5648.7144,
+        "y": -8868.611
+      }
+    },
+    {
+      "regionName": "Sewer",
+      "superRegionName": "A",
+      "location": {
+        "x": 4862.6064,
+        "y": -2367.2578
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "A",
+      "location": {
+        "x": 6588.6597,
+        "y": -6761.131
+      }
+    },
+    {
+      "regionName": "Tower",
+      "superRegionName": "A",
+      "location": {
+        "x": 4636.7925,
+        "y": -6748.2334
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": 1901.97,
+        "y": 59.588867
+      }
+    },
+    {
+      "regionName": "Alley",
+      "superRegionName": "B",
+      "location": {
+        "x": -1158.0048,
+        "y": -8066.301
+      }
+    },
+    {
+      "regionName": "Back",
+      "superRegionName": "B",
+      "location": {
+        "x": -3107.181,
+        "y": -7417.2607
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "B",
+      "location": {
+        "x": -27.670135,
+        "y": -2369.784
+      }
+    },
+    {
+      "regionName": "Garage",
+      "superRegionName": "B",
+      "location": {
+        "x": -2190.7827,
+        "y": -3848.0293
+      }
+    },
+    {
+      "regionName": "Rafters",
+      "superRegionName": "B",
+      "location": {
+        "x": -637.1397,
+        "y": -6070.6167
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "B",
+      "location": {
+        "x": -2167.2456,
+        "y": -6264.7715
+      }
+    },
+    {
+      "regionName": "Stairs",
+      "superRegionName": "B",
+      "location": {
+        "x": 1061.493,
+        "y": -6760.976
+      }
+    },
+    {
+      "regionName": "Tower",
+      "superRegionName": "B",
+      "location": {
+        "x": 168.89589,
+        "y": -5290.194
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "B",
+      "location": {
+        "x": -1271.6421,
+        "y": -1983.6248
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 2142.3635,
+        "y": -8964.969
+      }
+    },
+    {
+      "regionName": "Bottom",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 1922.6552,
+        "y": -2899.4626
+      }
+    },
+    {
+      "regionName": "Mail",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 1155.3333,
+        "y": -4808.6436
+      }
+    },
+    {
+      "regionName": "Top",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 2021.9575,
+        "y": -4596.936
+      }
+    },
+    {
+      "regionName": "Vent",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 3155.1648,
+        "y": -5338.5215
+      }
+    }
+  ]
+}

--- a/src/data/maps/sunset.json
+++ b/src/data/maps/sunset.json
@@ -1,0 +1,149 @@
+{
+  "uuid": "92584fbe-486a-b1b2-9faa-39b0f486b498",
+  "displayName": "Sunset",
+  "displayIcon": "https://media.valorant-api.com/maps/92584fbe-486a-b1b2-9faa-39b0f486b498/displayicon.png",
+  "listViewIcon": "https://media.valorant-api.com/maps/92584fbe-486a-b1b2-9faa-39b0f486b498/listviewicon.png",
+  "splash": "https://media.valorant-api.com/maps/92584fbe-486a-b1b2-9faa-39b0f486b498/splash.png",
+  "xMultiplier": 7.8e-05,
+  "yMultiplier": -7.8e-05,
+  "xScalarToAdd": 0.5,
+  "yScalarToAdd": 0.515625,
+  "callouts": [
+    {
+      "regionName": "Boba",
+      "superRegionName": "B",
+      "location": {
+        "x": 2200,
+        "y": -4800
+      }
+    },
+    {
+      "regionName": "Tiles",
+      "superRegionName": "Mid",
+      "location": {
+        "x": -1800,
+        "y": 400
+      }
+    },
+    {
+      "regionName": "Market",
+      "superRegionName": "B",
+      "location": {
+        "x": -200,
+        "y": -3400
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "B",
+      "location": {
+        "x": -600,
+        "y": -5850
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "B",
+      "location": {
+        "x": -2000,
+        "y": -5650
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "B",
+      "location": {
+        "x": -3400,
+        "y": -2600
+      }
+    },
+    {
+      "regionName": "Bottom",
+      "superRegionName": "Mid",
+      "location": {
+        "x": -1800,
+        "y": -2025
+      }
+    },
+    {
+      "regionName": "Courtyard",
+      "superRegionName": "Mid",
+      "location": {
+        "x": -600,
+        "y": -1200
+      }
+    },
+    {
+      "regionName": "Lobby",
+      "superRegionName": "A",
+      "location": {
+        "x": -1800,
+        "y": 2000
+      }
+    },
+    {
+      "regionName": "Main",
+      "superRegionName": "A",
+      "location": {
+        "x": -400,
+        "y": 2200
+      }
+    },
+    {
+      "regionName": "Link",
+      "superRegionName": "A",
+      "location": {
+        "x": 2200,
+        "y": 3000
+      }
+    },
+    {
+      "regionName": "Site",
+      "superRegionName": "A",
+      "location": {
+        "x": 1000,
+        "y": 3200
+      }
+    },
+    {
+      "regionName": "Elbow",
+      "superRegionName": "A",
+      "location": {
+        "x": 200,
+        "y": 4200
+      }
+    },
+    {
+      "regionName": "Alley",
+      "superRegionName": "A",
+      "location": {
+        "x": 3400,
+        "y": 3600
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Defender Side",
+      "location": {
+        "x": 3805.4785,
+        "y": -1989.0962
+      }
+    },
+    {
+      "regionName": "Top",
+      "superRegionName": "Mid",
+      "location": {
+        "x": 2000,
+        "y": -2000
+      }
+    },
+    {
+      "regionName": "Spawn",
+      "superRegionName": "Attacker Side",
+      "location": {
+        "x": -6025,
+        "y": -400
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adding a script to download maps data from valorant API, but only the keys we may need. If later we need more info we should add them to the GameMap class. My idea is to add polygons to the map class and store them with the script as well to later read the json file directly with `from_json()` method and draw it.

We can run the script with a new make command: `make download-data` 

The change in pre-commit is to not auto-sort the keys of the json