### PR TITLE
Fix/ci on push ci pipeline and deprecation warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,9 @@ name: CI Pipeline
 
 on:
     push:
-        branches:
-        -   main
+        branches: [main]
     pull_request:
-        branches:
-        -   main
+        branches: [main]
 
 jobs:
     build:
@@ -17,16 +15,17 @@ jobs:
                 python-version: [3.10.*]
 
         steps:
-        -   name: Check out the repository
-            uses: actions/checkout@v3
+        -   uses: actions/checkout@v4
 
         -   name: Set up Python ${{ matrix.python-version }}
-            uses: actions/setup-python@v4
+            uses: actions/setup-python@v5
             with:
                 python-version: ${{ matrix.python-version }}
 
         -   name: Install dependencies
-            run: pip install -r ./dev-requirements.txt
+            run: |
+                python -m pip install --upgrade pip
+                pip install -r ./dev-requirements.txt
 
         -   name: Run linting
             run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ fail_fast: true
 
 ci:
     autoupdate_schedule: weekly
-    skip: []
+    skip: [no-commit-to-branch]
     submodules: false
 
 repos:


### PR DESCRIPTION
Trying to fix error when we merge a PR and we push changes to main the no-commit-to-branch hook is failing. 

Also upgrading version due to deprecation warnings.