### PR TITLE
fix: do not run no-commit-to-branch hook on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
                 pip install -r ./dev-requirements.txt
 
         -   name: Run linting
+            env:
+                SKIP: no-commit-to-branch
             run: |
                 pre-commit run --all-files
                 mypy .


### PR DESCRIPTION
Finally skipping the no-commit-to-branch step on CI see in red below:

![Captura de pantalla 2024-08-19 002133](https://github.com/user-attachments/assets/ac9288a4-ffa2-44a3-aa8b-492e5eb1bd9e)
