### PR TITLE
fix: eliminate tautological assertions

### DIFF
--- a/tests/models/agent/test_ability.py
+++ b/tests/models/agent/test_ability.py
@@ -29,8 +29,30 @@ def test_invalid_ability_slot(invalid_ability_data):
 
 def test_ability_from_dict(ability_data):
     ability = Ability.from_dict(ability_data)
-    assert ability.slot == AbilitySlot(ability_data["slot"])
-    assert ability.name == ability_data["displayName"]
+
+    expected_slot = None
+    expected_name = None
+
+    if ability_data["slot"] == "Ability1":
+        expected_slot = AbilitySlot.Q_SLOT
+        expected_name = "Ability 1 Name"
+    elif ability_data["slot"] == "Ability2":
+        expected_slot = AbilitySlot.E_SLOT
+        expected_name = "Ability 2 Name"
+    elif ability_data["slot"] == "Grenade":
+        expected_slot = AbilitySlot.C_SLOT
+        expected_name = "Grenade Name"
+    elif ability_data["slot"] == "Ultimate":
+        expected_slot = AbilitySlot.X_SLOT
+        expected_name = "Ultimate Name"
+    elif ability_data["slot"] == "Passive":
+        expected_slot = AbilitySlot._SLOT
+        expected_name = "Passive Name"
+    else:
+        pytest.fail(f"Unexpected slot value: {ability_data['slot']}")
+
+    assert ability.slot == expected_slot
+    assert ability.name == expected_name
 
 
 def test_ability_to_dict(ability_data):

--- a/tests/models/agent/test_agent.py
+++ b/tests/models/agent/test_agent.py
@@ -58,21 +58,26 @@ def test_invalid_agent_uuid(invalid_agent_data):
 
 def test_agent_from_dict(agent_data):
     agent = Agent.from_dict(agent_data)
-    assert agent.uuid == AgentUUID(agent_data["uuid"])
-    assert agent.name == agent_data["displayName"].replace("/", "")
-    assert agent.display_icon == agent_data["displayIcon"]
-    assert agent.display_icon_small == agent_data["displayIconSmall"]
-    assert agent.role.uuid == RoleUUID(agent_data["role"]["uuid"])
-    assert agent.role.name == agent_data["role"]["displayName"]
-    assert len(agent.abilities) == len(agent_data["abilities"])
-    assert agent.abilities[0].slot == AbilitySlot(agent_data["abilities"][0]["slot"])
-    assert agent.abilities[0].name == agent_data["abilities"][0]["displayName"]
-    assert agent.abilities[1].slot == AbilitySlot(agent_data["abilities"][1]["slot"])
-    assert agent.abilities[1].name == agent_data["abilities"][1]["displayName"]
-    assert agent.abilities[2].slot == AbilitySlot(agent_data["abilities"][2]["slot"])
-    assert agent.abilities[2].name == agent_data["abilities"][2]["displayName"]
-    assert agent.abilities[3].slot == AbilitySlot(agent_data["abilities"][3]["slot"])
-    assert agent.abilities[3].name == agent_data["abilities"][3]["displayName"]
+
+    expected_abilities = [
+        (AbilitySlot.Q_SLOT, "Ability 1 Name"),
+        (AbilitySlot.E_SLOT, "Ability 2 Name"),
+        (AbilitySlot.C_SLOT, "Grenade Name"),
+        (AbilitySlot.X_SLOT, "Ultimate Name"),
+        (AbilitySlot._SLOT, "Passive Name"),
+    ]
+
+    assert agent.uuid == AgentUUID("601dbbe7-43ce-be57-2a40-4abd24953621")
+    assert agent.name == "TestAgent"
+    assert agent.display_icon == "icon.png"
+    assert agent.display_icon_small == "small_icon.png"
+    assert agent.role.uuid == RoleUUID("4ee40330-ecdd-4f2f-98a8-eb1243428373")
+    assert agent.role.name == "Controller"
+    assert len(agent.abilities) == 5
+
+    for ability, (expected_slot, expected_name) in zip(agent.abilities, expected_abilities):
+        assert ability.slot == expected_slot
+        assert ability.name == expected_name
 
 
 def test_agent_to_dict(agent_data):

--- a/tests/models/agent/test_role.py
+++ b/tests/models/agent/test_role.py
@@ -39,8 +39,27 @@ def test_invalid_role_uuid(invalid_role_data):
 
 def test_role_from_dict(role_data):
     role = Role.from_dict(role_data)
-    assert role.uuid == RoleUUID(role_data["uuid"])
-    assert role.name == role_data["displayName"]
+
+    expected_uuid = None
+    expected_name = None
+
+    if role_data["uuid"] == "4ee40330-ecdd-4f2f-98a8-eb1243428373":
+        expected_uuid = RoleUUID.CONTROLLER
+        expected_name = "Controller"
+    elif role_data["uuid"] == "dbe8757e-9e92-4ed4-b39f-9dfc589691d4":
+        expected_uuid = RoleUUID.DUELIST
+        expected_name = "Duelist"
+    elif role_data["uuid"] == "1b47567f-8f7b-444b-aae3-b0c634622d10":
+        expected_uuid = RoleUUID.INITIATOR
+        expected_name = "Initiator"
+    elif role_data["uuid"] == "5fc02f99-4091-4486-a531-98459a3e95e9":
+        expected_uuid = RoleUUID.SENTINEL
+        expected_name = "Sentinel"
+    else:
+        pytest.fail(f"Unexpected uuid value: {role_data['uuid']}")
+
+    assert role.uuid == expected_uuid
+    assert role.name == expected_name
 
 
 def test_role_to_dict(role_data):

--- a/tests/models/game_map/conftest.py
+++ b/tests/models/game_map/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture()
 def location_data():
-    return {"x": 10.0, "y": 20.0}
+    return {"x": 10.0, "y": -20.0}
 
 
 @pytest.fixture()

--- a/tests/models/game_map/test_callout.py
+++ b/tests/models/game_map/test_callout.py
@@ -3,12 +3,12 @@ import pytest
 from src.models.game_map.callout import Callout
 
 
-def test_callout_from_dict_initialization(callout_data):
+def test_callout_from_dict(callout_data):
     callout = Callout.from_dict(callout_data)
-    assert callout.region_name == callout_data["regionName"]
-    assert callout.super_region_name == callout_data["superRegionName"]
-    assert callout.location.x == callout_data["location"]["x"]
-    assert callout.location.y == callout_data["location"]["y"]
+    assert callout.region_name == "Test Region"
+    assert callout.super_region_name == "Test Super Region"
+    assert callout.location.x == 10.0
+    assert callout.location.y == -20.0
 
 
 def test_callout_instantiation_without_region_name_raises_keyerror(location_data):

--- a/tests/models/game_map/test_game_map.py
+++ b/tests/models/game_map/test_game_map.py
@@ -13,7 +13,9 @@ def map_metadata(callout_data):
     first_callout["location"] = callout_data["location"].copy()
 
     second_callout = callout_data.copy()
-    second_callout["location"] = {"x": callout_data["location"]["x"] + 1, "y": callout_data["location"]["y"] + 1}
+    second_callout["regionName"] = "Another Test Region"
+    second_callout["superRegionName"] = "Another Test Super Region"
+    second_callout["location"] = {"x": -5.0, "y": 5.0}
 
     return {
         "uuid": "224b0a95-48b9-f703-1bd8-67aca101a61f",
@@ -22,10 +24,10 @@ def map_metadata(callout_data):
         "listViewIcon": "list_icon.png",
         "splash": "splash.png",
         "xMultiplier": 2.0,
-        "yMultiplier": 2.0,
+        "yMultiplier": -2.0,
         "xScalarToAdd": 1.0,
-        "yScalarToAdd": 1.0,
-        "callouts": [callout_data, callout_data],
+        "yScalarToAdd": -1.0,
+        "callouts": [first_callout, second_callout],
     }
 
 
@@ -73,26 +75,37 @@ def test_invalid_map_uuid(invalid_map_data):
     assert str(excinfo.value) == f"'{invalid_map_data['uuid']}' is not a valid MapUUID"
 
 
-def test_map_from_dict_initialization(map_metadata):
+def test_game_map_from_dict(map_metadata):
     game_map = GameMap.from_dict(map_metadata)
-    assert game_map.uuid == MapUUID(map_metadata["uuid"])
-    assert game_map.name == map_metadata["displayName"]
-    assert game_map.display_icon == map_metadata["displayIcon"]
-    assert game_map.list_view_icon == map_metadata["listViewIcon"]
-    assert game_map.splash == map_metadata["splash"]
-    assert game_map.x_multiplier == map_metadata["xMultiplier"]
-    assert game_map.y_multiplier == map_metadata["yMultiplier"]
-    assert game_map.x_scalar_to_add == map_metadata["xScalarToAdd"]
-    assert game_map.y_scalar_to_add == map_metadata["yScalarToAdd"]
-    assert len(game_map.callouts) == len(map_metadata["callouts"])
-    assert game_map.callouts[0].region_name == map_metadata["callouts"][0]["regionName"]
-    assert game_map.callouts[1].region_name == map_metadata["callouts"][1]["regionName"]
+    assert game_map.uuid == MapUUID("224b0a95-48b9-f703-1bd8-67aca101a61f")
+    assert game_map.name == "Test Map"
+    assert game_map.display_icon == "icon.png"
+    assert game_map.list_view_icon == "list_icon.png"
+    assert game_map.splash == "splash.png"
+    assert game_map.x_multiplier == 2.0
+    assert game_map.y_multiplier == -2.0
+    assert game_map.x_scalar_to_add == 1.0
+    assert game_map.y_scalar_to_add == -1.0
+
+    assert len(game_map.callouts) == 2
+
+    first_callout = game_map.callouts[0]
+    assert first_callout.region_name == "Test Region"
+    assert first_callout.super_region_name == "Test Super Region"
+    assert first_callout.location.x == 10.0
+    assert first_callout.location.y == -20.0
+
+    second_callout = game_map.callouts[1]
+    assert second_callout.region_name == "Another Test Region"
+    assert second_callout.super_region_name == "Another Test Super Region"
+    assert second_callout.location.x == -5.0
+    assert second_callout.location.y == 5.0
 
 
-def test_map_from_dict_initialization_with_empty_values(empty_map_metadata):
+def test_game_map_from_dict_with_empty_values(empty_map_metadata):
     game_map = GameMap.from_dict(empty_map_metadata)
-    assert game_map.uuid == MapUUID(empty_map_metadata["uuid"])
-    assert game_map.name == empty_map_metadata["displayName"]
+    assert game_map.uuid == MapUUID("224b0a95-48b9-f703-1bd8-67aca101a61f")
+    assert game_map.name == "Test Map"
     assert game_map.display_icon == "icon.png"
     assert game_map.list_view_icon is None
     assert game_map.splash is None
@@ -103,11 +116,11 @@ def test_map_from_dict_initialization_with_empty_values(empty_map_metadata):
     assert len(game_map.callouts) == 0
 
 
-def test_map_from_dict_initialization_with_null_values(map_metadata_with_null_values):
+def test_game_map_from_dict_with_null_values(map_metadata_with_null_values):
     game_map = GameMap.from_dict(map_metadata_with_null_values)
-    assert game_map.uuid == MapUUID(map_metadata_with_null_values["uuid"])
-    assert game_map.name == map_metadata_with_null_values["displayName"]
-    assert game_map.display_icon == map_metadata_with_null_values["displayIcon"]
+    assert game_map.uuid == MapUUID("224b0a95-48b9-f703-1bd8-67aca101a61f")
+    assert game_map.name == "Test Map"
+    assert game_map.display_icon == "icon.png"
     assert game_map.list_view_icon is None
     assert game_map.splash is None
     assert game_map.x_multiplier == 1.0
@@ -118,7 +131,7 @@ def test_map_from_dict_initialization_with_null_values(map_metadata_with_null_va
 
 
 @pytest.mark.parametrize("missing_key", ["uuid", "displayName", "displayIcon"])
-def test_map_instantiation_missing_key_raises_keyerror(map_metadata, missing_key):
+def test_game_map_instantiation_missing_key_raises_keyerror(map_metadata, missing_key):
     map_metadata_missing_key = map_metadata.copy()
     del map_metadata_missing_key[missing_key]
 
@@ -126,18 +139,18 @@ def test_map_instantiation_missing_key_raises_keyerror(map_metadata, missing_key
         GameMap.from_dict(map_metadata_missing_key)
 
 
-def test_map_to_dict(map_metadata):
+def test_game_map_to_dict(map_metadata):
     game_map = GameMap.from_dict(map_metadata)
     assert game_map.to_dict() == map_metadata
 
 
-def test_map_round_trip(map_metadata):
+def test_game_map_round_trip(map_metadata):
     game_map = GameMap.from_dict(map_metadata)
     map_dict = game_map.to_dict()
     assert game_map == GameMap.from_dict(map_dict)
 
 
-def test_map_json_serialization(map_metadata):
+def test_game_map_json_serialization(map_metadata):
     game_map = GameMap.from_dict(map_metadata)
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         temp_file_path = temp_file.name

--- a/tests/models/game_map/test_location.py
+++ b/tests/models/game_map/test_location.py
@@ -10,8 +10,8 @@ def empty_location_data():
 
 def test_location_from_dict(location_data):
     location = Location(**location_data)
-    assert location.x == location_data["x"]
-    assert location.y == location_data["y"]
+    assert location.x == 10.0
+    assert location.y == -20.0
 
 
 def test_location_from_empty_dict(empty_location_data):


### PR DESCRIPTION
While adding new tests I realised that implemented tests were tautological (i.e. I was using same logic in test from the method i wanted to test) which made that if there was a bug in the logic, since it was the same, the test will pass. Fixing that by directly comparing results to predefined values.